### PR TITLE
Bootstrap: s2147 work

### DIFF
--- a/caom2-search-server/build.gradle
+++ b/caom2-search-server/build.gradle
@@ -37,4 +37,4 @@ dependencies {
 
 sourceCompatibility = 1.7
 group = 'org.opencadc'
-version = '2.1.8'
+version = '2.1.9'

--- a/caom2-search-server/build.gradle
+++ b/caom2-search-server/build.gradle
@@ -37,4 +37,4 @@ dependencies {
 
 sourceCompatibility = 1.7
 group = 'org.opencadc'
-version = '2.1.9'
+version = '2.1.10'

--- a/caom2-search-server/build.gradle
+++ b/caom2-search-server/build.gradle
@@ -37,4 +37,4 @@ dependencies {
 
 sourceCompatibility = 1.7
 group = 'org.opencadc'
-version = '2.1.10'
+version = '2.1.11'

--- a/caom2-search-server/src/main/resources/META-INF/resources/css/caom2_search.css
+++ b/caom2-search-server/src/main/resources/META-INF/resources/css/caom2_search.css
@@ -84,7 +84,7 @@
 #resultTable
 {
   width: 100%;
-  height: 640px;
+  height: 670px;
   outline: 0;
   background: #fff;
   border: 1px solid gray;

--- a/caom2-search-server/src/main/resources/META-INF/resources/css/caom2_search.css
+++ b/caom2-search-server/src/main/resources/META-INF/resources/css/caom2_search.css
@@ -38,6 +38,18 @@
   height: 100px !important;
 }
 
+/* These need to be !important as jquery ui will override it as well as bootstrap */
+.slick-row .slick-cell a
+{
+  color:#337ab7; !important
+}
+
+.slick-row .slick-cell a:hover
+{
+  text-decoration: underline; !important
+}
+
+
 .grid-container
 {
   width: 1180px;

--- a/caom2-search-server/src/main/resources/META-INF/resources/index.jsp
+++ b/caom2-search-server/src/main/resources/META-INF/resources/index.jsp
@@ -286,7 +286,9 @@
                                                     });
 
                                 searchApp.init();
+
                               });
+
           </script>
 
   <!-- Close off the wb-body -->

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
@@ -1738,10 +1738,6 @@
 
                             this._postQuerySubmission({upload_url: json.upload_url});
 
-                            var message = buildPanelMessage(startDate, netEnd, loadStart, loadEnd);
-
-                            $("#results-grid-footer").find(".grid-footer-label").text(message);
-
                             // Necessary at the end!
                             resultsVOTV.refreshGrid();
                           }.bind(this),

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
@@ -391,7 +391,52 @@
                         {
                           window.location.hash = $(this).find("a").first().attr("href");
                         });
+
+      this._initBackButtonHandling();
+
     };
+
+    /**
+     * Ensure back button navigates through tabs user (or app) has clicked through.
+     * @private
+     */
+
+    this._initBackButtonHandling = function()
+    {
+      // Add a hash of previous to the URL when a new tab is shown
+      $('a[data-toggle="tab"]').on('shown.bs.tab', function(e)
+                                            {
+                                              // Avoid duplication of history elements
+                                              $currentTarget = $(e.target);
+                                              $relatedTarget = $(e.relatedTarget);
+
+                                              if (($currentTarget.attr('href') != window.location.hash) &&
+                                                  ($currentTarget.attr('href') !== $relatedTarget.attr('href')) )
+                                              {
+                                                history.pushState(null, null, $currentTarget.attr('href'));
+                                              }
+
+                                            }
+      );
+
+      // Navigate to a tab when the history changes (back button is pressed)
+      window.addEventListener("popstate", function(e)
+                                          {
+                                            if (location.hash.length != 0)
+                                            {
+                                              $('[href="' + location.hash + '"]').tab('show');
+                                            }
+                                            else
+                                            {
+                                              $('.nav-tabs a:first').tab('show');
+                                            }
+                                          }
+      );
+
+      // Add hash to URL when search is completed & results tab loads
+
+
+    }
 
     /**
      * Remove empty or non-existent fields from the metadata.

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.columnbundles.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.columnbundles.js
@@ -368,6 +368,7 @@
                   "caom2:Observation.uri",
                   "caom2:Observation.collection",
                   "caom2:Observation.observationID",
+                  "caom2:Plane.productID",
                   "caom2:Plane.position.bounds.cval1",
                   "caom2:Plane.position.bounds.cval2",
                   "caom2:Plane.time.bounds.lower",
@@ -381,7 +382,6 @@
                   "caom2:Plane.energy.bounds.upper",
                   "caom2:Observation.proposal.id",
                   "caom2:Observation.proposal.pi",
-                  "caom2:Plane.productID",
                   "caom2:Plane.dataRelease",
                   "caom2:Plane.position.bounds.area",
                   "caom2:Plane.position.bounds",
@@ -424,7 +424,7 @@
                 "unitTypes": {
                   "caom2:Plane.energy.restwav": "m"
 	              },
-                "size": 12
+                "size": 13
               },
               "ObsCore": {
                 "columns": [

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
@@ -1058,7 +1058,7 @@
                                                       $.ajax({
                                                                url: this.configuration.options.targetResolverEndpoint + "/" + id,
                                                                data: {
-                                                                 term: encodeURIComponent(value),
+                                                                 term: value,
                                                                  resolver: resolver.toLowerCase()
                                                                },
                                                                method: "GET",
@@ -1081,9 +1081,8 @@
                                                                     "id": id
                                                                   };
 
-                                                                  // no, check resolve status
-                                                                  if (!data.hasOwnProperty("error") ||
-                                                                      (data.error === ""))
+                                                                  // no, check resolve status return value
+                                                                  if ((data.resolveStatus === "GOOD"))
                                                                   {
                                                                     this._trigger(ca.nrc.cadc.search.events.onTargetNameResolved, arg);
                                                                   }

--- a/caom2-search-server/src/main/resources/META-INF/resources/results.jsp
+++ b/caom2-search-server/src/main/resources/META-INF/resources/results.jsp
@@ -129,8 +129,5 @@
 
         </div>
         <div id="resultTable"></div>
-        <div id="results-grid-footer" class="grid-footer">
-            <span class="grid-footer-label"></span>
-        </div>
     </div>
 </div>

--- a/caom2-search-server/src/main/resources/META-INF/resources/timestamp.jsp
+++ b/caom2-search-server/src/main/resources/META-INF/resources/timestamp.jsp
@@ -15,6 +15,7 @@
 
 <div id="${param.utype}_formgroup" class="form-group data_release_date_panel">
     <div data-toggle="popover"
+         data-utype="${param.utype}"
          data-placement="${param.tipSide}"
          data-title="<fmt:message key="${param.utype}_FORM_LABEL" bundle="${langBundle}"/>"
          class="advancedsearch-tooltip glyphicon glyphicon-question-sign popover-blue popover-right">


### PR DESCRIPTION
URL history kept
product ID added to default columns in results
results table longer (to give a larger results display)
wrong login text red
30,000 result limit reinstated

footer fixes:
-  on bottom of page, fixed height
- links are fully justified (no margin)
on mobile: additional constraints dropdowns show Alll(#) instead of 'O items...'

Fixed during work:
- timestamp tooltip works now
-  'All' in additional constraints section now stays highlighted when selected


Known issues:
- back button doesn't navigate through tabs
- Mobile issues (other than one above) unresolved - new story created for these (in backlog)