### PR TITLE
s2224, ta 8997: Safari, Chrome, Firefox all now open preview link in …

### DIFF
--- a/caom2-search-server/README.md
+++ b/caom2-search-server/README.md
@@ -1,5 +1,5 @@
 
-### CAOM-2 Search interface v2.3.10
+### CAOM-2 Search interface v2.4.20
 
 <a href="https://travis-ci.org/opencadc/caom2ui"><img src="https://travis-ci.org/opencadc/caom2ui.svg?branch=master" /></a>
 

--- a/caom2-search-server/build.gradle
+++ b/caom2-search-server/build.gradle
@@ -40,4 +40,4 @@ dependencies {
 sourceCompatibility = 1.7
 group = 'org.opencadc'
 
-version = '2.4.1'
+version = '2.4.2'

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.columns.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.columns.js
@@ -146,7 +146,12 @@
                           )
                         }
 
-                        var w = window.open('', '_PREVIEW')
+                        // name parameter (second one) passed in to open()
+                        // leads to Safari not being able to focus on the document
+                        // (w.focus() returns undefined, implying the system can't do it)
+                        // Calling with no parameters works for Chrome, Safari & Firefox
+                        // as of Dec 2017 - s2224
+                        var w = window.open()
                         w.document.body.innerHTML = ''
 
                         // Open and close are here to stop browsers expecting more data.


### PR DESCRIPTION
…new tab, focusing on that tab.

wwebui repo, branch s2224 has build.gradle changes for AdvancedSearch & MaqSearch to pull v 2.4.2 of caom2-search-server.