### PR TITLE
s2430, rework: load data train popovers on MAQ switch toggle

### DIFF
--- a/caom2-search-server/build.gradle
+++ b/caom2-search-server/build.gradle
@@ -42,4 +42,4 @@ dependencies {
 
 sourceCompatibility = 1.7
 group = 'org.opencadc'
-version = '2.8.8'
+version = '2.8.9'

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
@@ -86,7 +86,6 @@
     var queryOverlay = $('#queryOverlay')
     var queryTab = $('#queryTab')
     var $tabContainer = $('#tabContainer')
-    var tooltipJsonData
 
     // For controlling MAQ Switch triggering data train load
     var isFirstLoad = true

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
@@ -86,6 +86,7 @@
     var queryOverlay = $('#queryOverlay')
     var queryTab = $('#queryTab')
     var $tabContainer = $('#tabContainer')
+    var tooltipJsonData
 
     // For controlling MAQ Switch triggering data train load
     var isFirstLoad = true
@@ -1188,18 +1189,20 @@
       // After the series of columns (Data Train) has loaded, then proceed.
       var postDataTrainLoad = function (_continue) {
         var activeSearchForm = this._getActiveForm()
+
         // Enable the switch again (was disabled prior to data train load to
         // make sure only one call is out at a time from this page
         activeSearchForm.enableMaqToggle()
 
+        // set tooltips url
+        var tooltipURL = 'json/tooltips_' + this.getPageLanguage() + '.json'
+
         if (_continue && isFirstLoad) {
 
-          // set tooltips
-          var tooltipURL = 'json/tooltips_' + this.getPageLanguage() + '.json'
-
+          // set main search form tooltips
           $.getJSON(tooltipURL, function (jsonData) {
-            caomSearchForm.loadTooltips(jsonData)
-            obsCoreSearchForm.loadTooltips(jsonData)
+            caomSearchForm.loadTooltips(jsonData, 'popover')
+            obsCoreSearchForm.loadTooltips(jsonData, 'popover')
           })
 
           // Don't process the queryfrom the URL if this is not the first page load.
@@ -1343,6 +1346,13 @@
             this._selectTab(destinationTabID)
           }
         }
+
+        // Initialize the data train tooltips
+        $.getJSON(tooltipURL, function (jsonData) {
+          caomSearchForm.loadTooltips(jsonData, 'dt-popover')
+          obsCoreSearchForm.loadTooltips(jsonData, 'dt-popover')
+        })
+
       }.bind(this)
 
       var caomSearchForm = this.getCAOMSearchForm()

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
@@ -96,6 +96,8 @@
     var columnManager = new ca.nrc.cadc.search.columns.ColumnManager()
     var resultsVOTV
 
+    var tooltipJsonData = {}
+
     var services = {
       autocompleteEndpoint: _options.autocompleteEndpoint,
       targetResolverEndpoint: _options.targetResolverEndpoint,
@@ -1200,8 +1202,11 @@
 
           // set main search form tooltips
           $.getJSON(tooltipURL, function (jsonData) {
+            tooltipJsonData = jsonData
             caomSearchForm.loadTooltips(jsonData, 'popover')
             obsCoreSearchForm.loadTooltips(jsonData, 'popover')
+            caomSearchForm.loadTooltips(jsonData, 'dt-popover')
+            obsCoreSearchForm.loadTooltips(jsonData, 'dt-popover')
           })
 
           // Don't process the queryfrom the URL if this is not the first page load.
@@ -1345,13 +1350,11 @@
             this._selectTab(destinationTabID)
           }
         }
-
-        // Initialize the data train tooltips
-        $.getJSON(tooltipURL, function (jsonData) {
-          caomSearchForm.loadTooltips(jsonData, 'dt-popover')
-          obsCoreSearchForm.loadTooltips(jsonData, 'dt-popover')
-        })
-
+        else {
+          // Initialize the data train tooltips
+          caomSearchForm.loadTooltips(tooltipJsonData, 'dt-popover')
+          obsCoreSearchForm.loadTooltips(tooltipJsonData, 'dt-popover')
+        }
       }.bind(this)
 
       var caomSearchForm = this.getCAOMSearchForm()

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
@@ -1064,9 +1064,9 @@
      * Given the JSON data, load the tooltips for those fields.
      * @param {{}}  jsonData    JSON data from external tooltips.
      */
-    this.loadTooltips = function (jsonData) {
+    this.loadTooltips = function (jsonData, divClass) {
       var tooltipCreator = new ca.nrc.cadc.search.TooltipCreator()
-      this.$form.find('[data-toggle="popover"]').each(
+      this.$form.find('[data-toggle="' + divClass + '"]').each(
         function (key, element) {
           var $liItem = $(element)
           this.handleTooltipLoad(
@@ -1083,7 +1083,7 @@
       // open at a time.
       $(document).on('click', function (e) {
         if ($(e.target).hasClass('glyphicon-remove-circle')) {
-          $('[data-toggle="popover"],[data-original-title]').each(function () {;
+          $('[data-toggle="' + divClass + '"],[data-original-title]').each(function () {;
             (
               (
                 $(this)
@@ -1095,7 +1095,7 @@
         }
 
         if ($(e.target).hasClass('glyphicon-question-sign')) {
-          $('[data-toggle="popover"]').each(function () {
+          $('[data-toggle="' + divClass + '"]').each(function () {
             if (
               !$(this).is(e.target) &&
               $(this).has(e.target).length === 0 &&

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/hierarchy.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/hierarchy.js
@@ -472,7 +472,7 @@
       )
 
       labelSpanFieldName.className = 'indent-small field-name'
-      labelSpanFieldName.innerHTML = select.title + '<div data-toggle="popover" data-utype="' + uType
+      labelSpanFieldName.innerHTML = select.title + '<div data-toggle="dt-popover" data-utype="' + uType
           + '" data-placement="' + position + '" data-title="' + select.title
           + '" class="advancedsearch-tooltip glyphicon glyphicon-question-sign popover-blue popover-left" data-original-title="" title="">\n' +
           '  </div>'


### PR DESCRIPTION
All popovers are loaded on first page load. Only the data train tooltips are loaded when the MAQ switch is flipped.