### PR TITLE
s2511, ta 11790: reduce obscore form work on page load: bring showObs…

### DIFF
--- a/caom2-search-server/build.gradle
+++ b/caom2-search-server/build.gradle
@@ -46,4 +46,4 @@ dependencies {
 
 sourceCompatibility = 1.7
 group = 'org.opencadc'
-version = '2.10.0'
+version = '2.10.1'

--- a/caom2-search-server/examples/default/build.gradle
+++ b/caom2-search-server/examples/default/build.gradle
@@ -22,7 +22,7 @@ configurations.all {
 dependencies {
 //    compile 'log4j:log4j:1.2.+'
 
-    compile 'org.opencadc:caom2-search-server:[2.10.0,)'
+    compile 'org.opencadc:caom2-search-server:[2.10.1,)'
     compile 'org.opencadc:cadc-uws-server:[1.2.1,)'
     compile 'org.opencadc:cadc-registry:[1.5.0,)'
 

--- a/caom2-search-server/src/main/resources/META-INF/resources/caom2_search.jsp
+++ b/caom2-search-server/src/main/resources/META-INF/resources/caom2_search.jsp
@@ -140,7 +140,7 @@
         </div>
       </div>
 
-      <div class="col-sm-12 resolver-result-tooltip">
+      <div class="col-sm-12 resolver-result-tooltip hidden">
         <strong><fmt:message key="RES_TARGET" bundle="${langBundle}"/></strong><br>
         <p class="resolver-result-target"></p>
         <strong><fmt:message key="RES_SERVICE" bundle="${langBundle}"/></strong><br>

--- a/caom2-search-server/src/main/resources/META-INF/resources/index.jsp
+++ b/caom2-search-server/src/main/resources/META-INF/resources/index.jsp
@@ -284,7 +284,8 @@
                                                                                "autoInitFlag": false,
                                                                                "applicationEndpoint": "<%= applicationEndpoint %>",
                                                                                "enableMAQ" : <%= enableMAQ %>,
-                                                                               "activateMAQ": <%= activateMAQ %>
+                                                                               "activateMAQ": <%= activateMAQ %>,
+                                                                                "showObscoreTab" : <%= showObsCoreTab %>
                                                                              });
 
                                 searchApp.subscribe(ca.nrc.cadc.search.events.onAdvancedSearchInit,


### PR DESCRIPTION
…CoreTab boolean into javascript.

Meant rearranging where in the javascript the forms were initialized, so that work could be done conditionally depending on the showObsCoreTab boolean. 

Should be code reviewed with wwebui/AdvancedSearch, s2511 branch code. 