### PR TITLE
s2488, ta 12171: set example properties file to point to argus

### DIFF
--- a/caom2-search-server/examples/default/org.opencadc.search.properties
+++ b/caom2-search-server/examples/default/org.opencadc.search.properties
@@ -1,5 +1,5 @@
 # The TAP Service ID to resolve.
-org.opencadc.search.tap-service-id = ivo://cadc.nrc.ca/tap
+org.opencadc.search.tap-service-id = ivo://cadc.nrc.ca/argus
 
 # The endpoint for this application. 
 org.opencadc.search.app-service-endpoint = /search


### PR DESCRIPTION
Switch to use argus as this is what will be used going forward (existing tap service is going away eventually.) 