### PR TITLE
s2559: NullPointerException for older collections

### DIFF
--- a/caom2-meta-ui/build.gradle
+++ b/caom2-meta-ui/build.gradle
@@ -22,10 +22,10 @@ configurations.all {
 
 sourceCompatibility = '1.7'
 group = 'ca.nrc.cadc'
-version = '1015'
+version = '1016'
 
 dependencies {
-    compile 'org.opencadc:caom2-ui-server:[1.2.5,)'
+    compile 'org.opencadc:caom2-ui-server:[1.2.6,)'
 
     providedCompile 'javax.servlet:javax.servlet-api:[3.1.0,)'
     providedCompile 'javax.servlet:javax.servlet-api:[3.0.0,)'

--- a/caom2-ui-server/build.gradle
+++ b/caom2-ui-server/build.gradle
@@ -35,4 +35,4 @@ dependencies {
 
 sourceCompatibility = '1.7'
 group = 'org.opencadc'
-version = '1.2.5'
+version = '1.2.6'

--- a/caom2-ui-server/src/main/java/ca/nrc/cadc/caom2/ui/server/SS.java
+++ b/caom2-ui-server/src/main/java/ca/nrc/cadc/caom2/ui/server/SS.java
@@ -358,8 +358,7 @@ public class SS {
             "<br>sampleSNR: " +
             m.sampleSNR;
     }
-
-
+    
     public static String toMemberString(final String contextPath, final Observation o, final String parentID) {
         final StringBuilder sb = new StringBuilder();
 

--- a/caom2-ui-server/src/main/java/ca/nrc/cadc/caom2/ui/server/SS.java
+++ b/caom2-ui-server/src/main/java/ca/nrc/cadc/caom2/ui/server/SS.java
@@ -359,6 +359,7 @@ public class SS {
             m.sampleSNR;
     }
 
+
     public static String toMemberString(final String contextPath, final Observation o, final String parentID) {
         final StringBuilder sb = new StringBuilder();
 
@@ -407,11 +408,22 @@ public class SS {
         return sb.toString();
     }
 
-
     public static String toString(final URI uri) throws MalformedURLException {
         final MessageFormat format = new MessageFormat("<a class=\"provenance-reference\" href=\"{0}\">{0}</a>");
-        final URL url = uri.isAbsolute() ? uri.toURL() : new URL("http://" + uri.toString());
-        return format.format(new Object[] {url.toExternalForm()});
+        //Default is to return an empty string if the uri is null
+        String uriString = "";
+        if (uri != null ) {
+            final URL url = uri.isAbsolute() ? uri.toURL() : new URL("http://" + uri.toString());
+            uriString = format.format(new Object[] {url.toExternalForm()});
+        }
+        return uriString;
+    }
+
+    // URIs for checksums start with md5: which fails the toString(URI) above with a MalformedURLException
+    // This function guards against nulls in the data set which cause a Null Pointer Exception
+    // if/when encountered during jsp processing.
+    public static String getChecksum(final URI checksumUri) {
+        return (checksumUri == null) ? "" : checksumUri.toString();
     }
 
     public static String toString(Provenance p) {

--- a/caom2-ui-server/src/main/resources/META-INF/resources/artifact.jsp
+++ b/caom2-ui-server/src/main/resources/META-INF/resources/artifact.jsp
@@ -39,22 +39,22 @@ request.setAttribute("artifact", a);
     </tr>
     <tr>
       <td>contentType</td>
-      <td><%= artifact.contentType %>
+      <td><%= SS.toString(artifact.contentType) %>
       </td>
     </tr>
     <tr>
       <td>contentLength</td>
-      <td><%= artifact.contentLength %>
+      <td><%= SS.toString(artifact.contentLength) %>
       </td>
     </tr>
     <tr>
       <td>contentChecksum</td>
-      <td><%= artifact.contentChecksum.toString() %>
+      <td><%= SS.getChecksum(artifact.contentChecksum) %>
       </td>
     </tr>
     <tr>
       <td>contentRelease</td>
-      <td><%= artifact.contentRelease %>
+      <td><%= SS.toString(artifact.contentRelease) %>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Found by Chris in acceptance review on rc. Artifacts with null checksum were throwing Null Pointer Exceptions. Existing function to render URIs didn't work because md5: as a prefix fails validation (get a MalformedURIException thrown.). Added a simple function to check for null checksum (and return "" as the others do,) - added some more buffering in the artifact.jsp so the toString() functions are used where necessary. Added a check in the existing toString(URI) so if the uri is null, the function returns "" instead of throwing an exception. 

Tested with observations from SDSS (null contentChecksum in artifacts) and observation id jbeoft020 (which has an artifact contentChecksum included.) 