### PR TITLE
CADC-8495: enable spatial checkout box for target upload files

### DIFF
--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
@@ -1069,7 +1069,7 @@
             var fromInputFile = this._getActiveForm().hasInputFile()
             var doSpatialCutout = this._getActiveForm().doSpatialCutout()
             var doSpectralCutout = this._getActiveForm().doSpectralCutout()
-            var downloadTuples = [];
+            var downloadTuples = []
 
             // clear hidden URI inputs from any prior searches first
             downloadForm.find("input[name='uri']").remove()
@@ -1094,7 +1094,7 @@
                   // set up tuples which will be sent to downloadManager
                   // downloadManager request will have multipart data, using
                   // a JSON blob to transmit tuples built below
-                  
+
                   // Need to build a spatial cutout DALI string for each selected row.
                   var $nextPlaneCutout = 'CIRCLE ' + $nextRow['caom2:Upload.ra'] + " " + $nextRow['caom2:Upload.dec']
                     + ' ' + $nextRow['caom2:Upload.radius']
@@ -1163,7 +1163,7 @@
               // Now get down to submitting the data
               if ((fromInputFile === true) && (doSpatialCutout === true)) {
                 // iterate through downloadTuples and make the badgerfish json
-                var badgerfishTuples = new Array();
+                var badgerfishTuples = new Array()
                 for (i=0; i<downloadTuples.length; i++) {
                   var tupleJSON = {"tuple":
                       {
@@ -1172,11 +1172,11 @@
                         "label":{"$": downloadTuples[i].label }
                       }
                   }
-                  badgerfishTuples.push(tupleJSON);
+                  badgerfishTuples.push(tupleJSON)
                 }
 
                 // create payload item
-                var jsonTuples = {"tupleList": {"$": badgerfishTuples }};
+                var jsonTuples = {"tupleList": {"$": badgerfishTuples }}
 
                 var multiPartData = new FormData()
 
@@ -1187,8 +1187,8 @@
                 }
 
                 // Add spectral cutout if defined
-                // Spectral cutouts are included in JSON tuple data
-                if (doSpectralCutout == true) {
+                // Spatial cutouts are included in JSON tuple data
+                if (doSpectralCutout === true) {
                   var specCutout = downloadForm.find("input[name='band']")
                   multiPartData.append('band', specCutout.val())
                 }
@@ -1220,7 +1220,7 @@
                 })
                 .fail(function (jqXHR, textStatus, errorThrown) {
                   alert(errorThrown)
-                });
+                })
 
               } else {
                 // do original call

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
@@ -1066,12 +1066,12 @@
           downloadFormSubmit.off().click(function (event) {
             event.preventDefault()
 
-            // Behaviour here depends on whether request contains
-            // a target upload file or not
-            var fromInputFile = this._getActiveForm().hasInputFile();
+            var fromInputFile = this._getActiveForm().hasInputFile()
+            var doSpatialCutout = this._getActiveForm().doSpatialCutout()
+            var doSpectralCutout = this._getActiveForm().doSpectralCutout()
             var downloadTuples = [];
 
-            // clear hidden inputs from any prior searches first
+            // clear hidden URI inputs from any prior searches first
             downloadForm.find("input[name='uri']").remove()
 
             // Collect & prepare data to be submitted
@@ -1088,14 +1088,14 @@
                 // uri is used for download request
                 var $nextPlaneURI = $nextRow['caom2:Plane.publisherID.downloadable']
 
-                // check for use of target upload file
-                if (fromInputFile) {
+                // check for request combination that will lead to tuple generation
+                if ((fromInputFile === true) && (doSpatialCutout === true)) {
 
                   // set up tuples which will be sent to downloadManager
                   // downloadManager request will have multipart data, using
                   // a JSON blob to transmit tuples built below
-
-                  // build spatial cutout DALI string
+                  
+                  // Need to build a spatial cutout DALI string for each selected row.
                   var $nextPlaneCutout = 'CIRCLE ' + $nextRow['caom2:Upload.ra'] + " " + $nextRow['caom2:Upload.dec']
                     + ' ' + $nextRow['caom2:Upload.radius']
 
@@ -1161,7 +1161,7 @@
               }
 
               // Now get down to submitting the data
-              if (fromInputFile) {
+              if ((fromInputFile === true) && (doSpatialCutout === true)) {
                 // iterate through downloadTuples and make the badgerfish json
                 var badgerfishTuples = new Array();
                 for (i=0; i<downloadTuples.length; i++) {
@@ -1179,9 +1179,18 @@
                 var jsonTuples = {"tupleList": {"$": badgerfishTuples }};
 
                 var multiPartData = new FormData()
+
+                // Add runid if defined
                 var runID = downloadForm.find("input[name='runid']").val()
                 if (runID !=  null) {
                   multiPartData.append('runid', runID)
+                }
+
+                // Add spectral cutout if defined
+                // Spectral cutouts are included in JSON tuple data
+                if (doSpectralCutout == true) {
+                  var specCutout = downloadForm.find("input[name='band']")
+                  multiPartData.append('band', specCutout.val())
                 }
 
                 // 'Blob' type is requred to have the 'filename="blob" parameter added

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
@@ -907,10 +907,10 @@
                 ),
                 true
               )
-              $("input[name$='.DOWNLOADCUTOUT']").prop('checked', false)
+              $("input[name$='.energy.DOWNLOADCUTOUT']").prop('checked', false)
               this.toggleDisabled(
                 $(
-                  '#' + this.id + " input[name$='.DOWNLOADCUTOUT']"
+                  '#' + this.id + " input[name$='.energy.DOWNLOADCUTOUT']"
                 ),
                 true
               )
@@ -924,7 +924,7 @@
               )
               this.toggleDisabled(
                 $(
-                  '#' + this.id + " input[name$='.DOWNLOADCUTOUT']"
+                  '#' + this.id + " input[name$='.energy.DOWNLOADCUTOUT']"
                 ),
                 false
               )
@@ -1837,6 +1837,16 @@
       return (inputFile.length > 0 &&
         !inputFile.prop('disabled') &&
         inputFile.val() !== '')
+    }
+
+    this.doSpatialCutout = function () {
+      var spatialCutout = this.$form.find("input[name$='.position.DOWNLOADCUTOUT']")
+      return spatialCutout.prop('checked')
+    }
+
+    this.doSpectralCutout = function () {
+      var spectralCutout = this.$form.find("input[name$='.energy.DOWNLOADCUTOUT']")
+      return spectralCutout.prop('checked')
     }
 
     /**


### PR DESCRIPTION
Note that spectral cutout checkbox is still disabled.

Browser tests run against my test vm. No extra tests added for this code change as it's partially removing what is considered a temporary code path (disabling both cutout boxes for the target upload file.) 