### PR TITLE
CADC-8179: cutout checkbox disabled by default, enabled when corresponding input exists.

### DIFF
--- a/caom2-search-server/src/main/resources/META-INF/resources/boolean.jsp
+++ b/caom2-search-server/src/main/resources/META-INF/resources/boolean.jsp
@@ -19,6 +19,6 @@
     <div class="form-group">
         <cadc:checkbox checkboxName="${param.name}" i18nKey="${param.name}_FORM_LABEL" />
         <input type="hidden"
-               name="<%= FormConstraint.FORM_NAME %>" disabled >
+               name="<%= FormConstraint.FORM_NAME %>" disabled="disabled"/>
     </div>
 </div>

--- a/caom2-search-server/src/main/resources/META-INF/resources/boolean.jsp
+++ b/caom2-search-server/src/main/resources/META-INF/resources/boolean.jsp
@@ -7,10 +7,18 @@
 <%@ taglib tagdir="/WEB-INF/tags/cadc" prefix="cadc" %>
 
 
-<div class="col-sm-12 label_tooltip_${param.tipSide}">
+<div class="label_tooltip_${param.tipSide}">
+
+    <div data-toggle="popover"
+         data-utype="${param.name}"
+         data-placement="${param.tipSide}"
+         data-title="<fmt:message key="${param.name}_FORM_LABEL" bundle="${langBundle}"/>"
+         class="advancedsearch-tooltip glyphicon glyphicon-question-sign popover-blue popover-right">
+    </div>
+
     <div class="form-group">
         <cadc:checkbox checkboxName="${param.name}" i18nKey="${param.name}_FORM_LABEL" />
         <input type="hidden"
-               name="<%= FormConstraint.FORM_NAME %>" >
+               name="<%= FormConstraint.FORM_NAME %>" disabled >
     </div>
 </div>

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
@@ -858,6 +858,7 @@
     this.currentTimeoutID = null
 
     this.targetNameFieldID = null
+    this.spectralCoverageFieldID = null
 
     /**
      * The data train at the bottom of the form.
@@ -887,6 +888,9 @@
       this.targetNameFieldID = $currForm
         .find("input[name$='@Shape1.value']")
         .prop('id')
+      this.spectralCoverageFieldID = $currForm
+        .find("input[name$='@Energy.value']")
+        .prop('id')
 
       $currForm.find('.search_criteria_input').on(
         'change input',
@@ -902,32 +906,16 @@
             if ($(event.target).val() !== '') {
               $('.targetList_clear').show()
               this.toggleDisabled(
-                $(
-                  '#' + this.id + " input[id='" + this.targetNameFieldID + "']"
-                ),
+                $('#' + this.id + " input[id='" + this.targetNameFieldID + "']"),
                 true
               )
-              $("input[name$='.energy.DOWNLOADCUTOUT']").prop('checked', false)
-              this.toggleDisabled(
-                $(
-                  '#' + this.id + " input[name$='.energy.DOWNLOADCUTOUT']"
-                ),
-                true
-              )
-
+              this._enableSpatialCutoutCheckbox(true)
             } else {
               this.toggleDisabled(
-                $(
-                  '#' + this.id + " input[id='" + this.targetNameFieldID + "']"
-                ),
+                $('#' + this.id + " input[id='" + this.targetNameFieldID + "']"),
                 false
               )
-              this.toggleDisabled(
-                $(
-                  '#' + this.id + " input[name$='.energy.DOWNLOADCUTOUT']"
-                ),
-                false
-              )
+              this._enableSpatialCutoutCheckbox(false)
             }
           }.bind(this)
         )
@@ -1323,6 +1311,8 @@
         }
 
         this.toggleDisabled($("input[id='" + id + "_targetList']"), hasValue)
+        // Enable the spatial cutout checkbox if there is a value in the target resolver input
+        this._enableSpatialCutoutCheckbox(hasValue)
 
         if (hasValue === true && resolver !== 'NONE') {
           this.clearTimeout()
@@ -1391,6 +1381,14 @@
           this._clearTargetNameResolutionStatus()
         }
       } else if ($node.hasClass('ui_unitconversion_input')) {
+
+          if (id === this.spectralCoverageFieldID) {
+            //toggle the spectral cutout checkbox as appropriate
+            this._indicateInputPresence(hasValue, id, value)
+            // Spectral cutout checkbox is enabled if there is input
+            this._enableSpectralCutoutCheckbox(hasValue)
+          }
+
         // Pass request to server
         $.getJSON(
           autocompleteURL, {
@@ -1827,6 +1825,8 @@
       resolverPopover.popover('hide')
     }
 
+
+
     /**
      * Check current form to see if upload target file is given
      * @returns {boolean}
@@ -1847,6 +1847,24 @@
     this.doSpectralCutout = function () {
       var spectralCutout = this.$form.find("input[name$='.energy.DOWNLOADCUTOUT']")
       return spectralCutout.prop('checked')
+    }
+
+    this._enableSpatialCutoutCheckbox = function (enableBox) {
+      var spatialCutout = this.$form.find("input[name$='.position.DOWNLOADCUTOUT']")
+      if (enableBox === true) {
+        // Clear checkbox so it's not picked up as part of search request
+        spatialCutout.prop('checked', false)
+      }
+      this.toggleDisabled(spatialCutout, !enableBox)
+    }
+
+    this._enableSpectralCutoutCheckbox = function (enableBox) {
+      var spectralCutout = this.$form.find("input[name$='.energy.DOWNLOADCUTOUT']")
+      if (enableBox === true) {
+        // Clear checkbox so it's not picked up as part of search request
+        spectralCutout.prop('checked', false)
+      }
+      this.toggleDisabled(spectralCutout, !enableBox)
     }
 
     /**
@@ -2067,13 +2085,9 @@
         $(this).val('')
       })
 
-      $('#' + this.id + "input[name$='.DOWNLOADCUTOUT']").prop('checked', false)
-      this.toggleDisabled(
-        $(
-          '#' + this.id + " input[name$='.DOWNLOADCUTOUT']"
-        ),
-        false
-      )
+      // Both cutout boxes are disabled by default
+      this._enableSpectralCutoutCheckbox(false)
+      this._enableSpatialCutoutCheckbox(false)
 
       this.$form.find('input.search_criteria_input').each(
         function (key, value) {

--- a/caom2-search-server/src/main/resources/META-INF/resources/json/tooltips_en.json
+++ b/caom2-search-server/src/main/resources/META-INF/resources/json/tooltips_en.json
@@ -73,7 +73,7 @@
   },
   "Plane.energy.DOWNLOADCUTOUT": {
     "tipHTML":
-      "<p>Enter a \"Spectral Coverage\" value to enable this option. </p><p>Check the box to return image cutouts rather than full images. Cutouts will be constrained to the range in the \"Spectral Coverage\" box.</p>"
+      "<p>Enter a \"Spectral Coverage\" value to enable this option. </p><p>Check the box to return a restricted spectral range rather than the full file. Cutouts will be constrained to the range in the \"Spectral Coverage\" box.</p>"
   },
   "download_data": {
     "tipHTML":

--- a/caom2-search-server/src/main/resources/META-INF/resources/json/tooltips_en.json
+++ b/caom2-search-server/src/main/resources/META-INF/resources/json/tooltips_en.json
@@ -37,7 +37,7 @@
   },
   "Plane.position.DOWNLOADCUTOUT": {
     "tipHTML":
-      "Check this box to return image cutouts rather than full images. Cutouts will be centred on the location determined from the \"Target\" box. The size of the cutouts will be twice the radius specified in the \"Target\" box. If no radius is specified then a default of 1 arcmin is used. Cutouts for a list of targets from \"Choose File\" are not yet implemented."
+      "<p>Enter a \"Target\" value or select an \"Upload Targets\" file to enable this search option.</p><p>Check the box to return image cutouts rather than full images. Cutouts will be centred on the location determined by the resolver for each target provided. The size of the cutouts will be twice the radius specified. If no radius is specified then a default of 1 arcmin is used.</p>"
   },
   "Plane.time.bounds.samples": {
     "tipHTML":
@@ -73,7 +73,7 @@
   },
   "Plane.energy.DOWNLOADCUTOUT": {
     "tipHTML":
-      "Check this box to return image cutouts rather than full images. Cutouts will be constrained to the range in the \"Spectral Coverage\" box."
+      "<p>Enter a \"Spectral Coverage\" value to enable this option. </p><p>Check the box to return image cutouts rather than full images. Cutouts will be constrained to the range in the \"Spectral Coverage\" box.</p>"
   },
   "download_data": {
     "tipHTML":

--- a/caom2-search-server/src/main/resources/META-INF/resources/json/tooltips_fr.json
+++ b/caom2-search-server/src/main/resources/META-INF/resources/json/tooltips_fr.json
@@ -37,7 +37,7 @@
   },
   "Plane.position.DOWNLOADCUTOUT": {
     "tipHTML":
-      "Cocher cette option si vous voulez effectuer un d&eacute;coupage spatial des images &agrave; r&eacute;cup&eacute;rer. Les zones de d&eacute;coupages sont centr&eacute;es sur les valeurs des coordonn&eacute;es qui correspondent &agrave; celle du nom d'objet sp&eacute;cifi&eacute;. Le diam&egrave;tre de la zone de d&eacute;coupage est d'une minute d'arc par d&eacute;faut. Il n'est pas encore possible d'utiliser cet option si on soumet une liste d'objets pour la recherche."
+      "<p>Saisissez une valeur &laquo;Target&raquo ou sélectionnez un fichier &laquo;Upload Targets&raquo pour activer cette option.</p><p>Cocher cette option si vous voulez effectuer un d&eacute;coupage spatial des images &agrave; r&eacute;cup&eacute;rer. Les zones de d&eacute;coupages sont centr&eacute;es sur les valeurs des coordonn&eacute;es qui correspondent &agrave; celle du nom d'objet sp&eacute;cifi&eacute;. Le diam&egrave;tre de la zone de d&eacute;coupage est d'une minute d'arc par d&eacute;faut.</p>"
   },
   "Plane.time.bounds.samples": {
     "tipHTML":
@@ -73,7 +73,7 @@
   },
   "Plane.energy.DOWNLOADCUTOUT": {
     "tipHTML":
-      "Utiliser cet option si vous voulez r&eacute;cup&eacute;rer un d&eacute;coupage spectral plut&ocirc;t que les images compl&egrave;tes. Les contraintes pour le d&eacute;coupage sont sp&eacute;cifi&eacute;es via l'option &laquo;Spectral Coverage&raquo;."
+      "<p>Saisissez une valeur &laquo;Spectral Coverage&raquo pour activer cette option.</p><p>Utiliser cet option si vous voulez r&eacute;cup&eacute;rer un d&eacute;coupage spectral plut&ocirc;t que les images compl&egrave;tes. Les contraintes pour le d&eacute;coupage sont sp&eacute;cifi&eacute;es via l'option &laquo;Spectral Coverage&raquo;.</p>"
   },
   "download_data": {
     "tipHTML":

--- a/caom2-search-server/src/main/resources/META-INF/resources/json/tooltips_fr.json
+++ b/caom2-search-server/src/main/resources/META-INF/resources/json/tooltips_fr.json
@@ -73,7 +73,7 @@
   },
   "Plane.energy.DOWNLOADCUTOUT": {
     "tipHTML":
-      "<p>Saisissez une valeur &laquo;Spectral Coverage&raquo pour activer cette option.</p><p>Utiliser cet option si vous voulez r&eacute;cup&eacute;rer un d&eacute;coupage spectral plut&ocirc;t que les images compl&egrave;tes. Les contraintes pour le d&eacute;coupage sont sp&eacute;cifi&eacute;es via l'option &laquo;Spectral Coverage&raquo;.</p>"
+      "<p>Saisissez une valeur &laquo;Spectral Coverage&raquo pour activer cette option.</p><p>Utiliser cet option si vous voulez r&eacute;cup&eacute;rer un d&eacute;coupage spectral plut&ocirc;t que les fichiers compl&egrave;tes. Les contraintes pour le d&eacute;coupage sont sp&eacute;cifi&eacute;es via l'option &laquo;Spectral Coverage&raquo;.</p>"
   },
   "download_data": {
     "tipHTML":


### PR DESCRIPTION
Tooltips enabled for both checkboxes, with instructions on how to enable them.

AdvancedSearch browser test suite ran successfully.

Manual tests included:
- ensure checkboxes are disabled on page load, and on form reset
- ensure tooltips & tooltip icon work (after page fully loads)
- test click-through of spatial cutout to download manager works