### PR TITLE
CADC-8637: results columns reflect target or target upload file use

### DIFF
--- a/caom2-search-server/build.gradle
+++ b/caom2-search-server/build.gradle
@@ -46,5 +46,5 @@ dependencies {
 
 sourceCompatibility = 1.8
 group = 'org.opencadc'
-version = '2.12.5'
+version = '2.12.6'
 

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.app.js
@@ -817,34 +817,31 @@
           var selectedCollections = this._getActiveForm().getCollectionSelectID()
           var currentCollections = $(
               '#' + selectedCollections.replace('.', '\\.')).val()
-          if (resultsVOTV) {
-            if (currentCollections.sort().join('') ===
-                previousCollections.sort().join('')) {
-              // Save viewer state from previous search
-              preserveColumnState = true
-              prevColumns = resultsVOTV.getColumns()
 
-              // Note: Results table column state is retained if the collection
-              // set selected is the same from one search to the next.
-              //  If an upload target file was used, additional columns will be
-              // added to the results table. If the results table is removed from
-              // the search, and the collections set stays the same, these additional
-              // columns are left in the results column (empty, as the search will return
-              // no data for them.) Expected behaviour is the columns would only be
-              // displayed if a target upload file is in the current search.
-              // Issue opened in github: https://github.com/opencadc/caom2ui/issues/182
-              // HJ, June 2020
-              prevDisplayedColumns = resultsVOTV.getDisplayedColumns()
-              prevColumnSelects = resultsVOTV.getUpdatedColumnSelects()
-              prevSortOptions['sortcol'] = resultsVOTV.sortcol
-              prevSortOptions['sortAsc'] = resultsVOTV.sortAsc
+          var cadcForm = args.cadcForm
+
+          if (resultsVOTV) {
+            // the results column set is retained if the collection used
+            // in the search is the same AND the form itself says it
+            // should be prserved
+            if ( (currentCollections.sort().join('') ===
+                previousCollections.sort().join('') )
+              && (cadcForm.preserveColumnSet() === true) ) {
+
+                // Save viewer state from previous search
+                preserveColumnState = true
+                prevColumns = resultsVOTV.getColumns()
+
+                prevDisplayedColumns = resultsVOTV.getDisplayedColumns()
+                prevColumnSelects = resultsVOTV.getUpdatedColumnSelects()
+                prevSortOptions['sortcol'] = resultsVOTV.sortcol
+                prevSortOptions['sortAsc'] = resultsVOTV.sortAsc
+
             }
 
             resultsVOTV.destroy()
           }
           previousCollections = currentCollections
-
-          var cadcForm = args.cadcForm
 
           // Searching on different data.  Switch the columns.
           if (!this.activeFormID || !cadcForm.isActive(this.activeFormID)) {

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
@@ -1846,7 +1846,7 @@
     /**
      * Check to see if the current column set has been augmented,
      * as compared to current form fields.
-     * @returns {*}
+     * @returns {boolean}
      */
     this.preserveColumnSet = function () {
       // hasAugmentedColumnSet reflects what happened on the previous form

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
@@ -138,6 +138,10 @@
     this.config = _config
     this.options = _options
 
+    // Used to flag whether the column set has any form field-related
+    // columns added.
+    this.hasAugmentedColumnSet = false
+
     /**
      * @type {Metadata|cadc.vot.Metadata}
      */
@@ -1839,6 +1843,17 @@
         inputFile.val() !== '')
     }
 
+    /**
+     * Check to see if the current column set has been augmented,
+     * as compared to current form fields.
+     * @returns {*}
+     */
+    this.preserveColumnSet = function () {
+      // hasAugmentedColumnSet reflects what happened on the previous form
+      // submit.
+      return this.hasInputFile() === this.hasAugmentedColumnSet
+    }
+
     this.doSpatialCutout = function () {
       var spatialCutout = this.$form.find("input[name$='.position.DOWNLOADCUTOUT']")
       return spatialCutout.prop('checked')
@@ -1883,6 +1898,9 @@
       if (this.hasInputFile() === true) {
         // functions that use this are expecting a jquery object
         columnIDs = $(this.configuration.addDefaultUploadColumns(columnIDs.toArray()))
+        this.hasAugmentedColumnSet = true
+      } else {
+        this.hasAugmentedColumnSet = false
       }
       return columnIDs
     }
@@ -1902,6 +1920,9 @@
 
       if (this.hasInputFile() === true) {
         allColumnIDs = this.configuration.addUploadColumns(allColumnIDs)
+        this.hasAugmentedColumnSet = true
+      } else {
+        this.hasAugmentedColumnSet = false
       }
       return allColumnIDs
     }

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
@@ -1844,13 +1844,16 @@
     }
 
     /**
-     * Check to see if the current column set has been augmented,
-     * as compared to current form fields.
+     * Determine if the current column set be preserved through the next search.
      * @returns {boolean}
      */
     this.preserveColumnSet = function () {
+      // Check to see if the current column set has been augmented,
+      // as compared to current form fields.
       // hasAugmentedColumnSet reflects what happened on the previous form
       // submit.
+
+      // Check target upload file augmented column requirements
       return this.hasInputFile() === this.hasAugmentedColumnSet
     }
 

--- a/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
+++ b/caom2-search-server/src/main/resources/META-INF/resources/js/cadc.search.form.js
@@ -1844,7 +1844,7 @@
     }
 
     /**
-     * Determine if the current column set be preserved through the next search.
+     * Determine if the current column set can be preserved through the next search.
      * @returns {boolean}
      */
     this.preserveColumnSet = function () {


### PR DESCRIPTION
Solves github issue:

https://github.com/opencadc/caom2ui/issues/182

Tested manually, switching between target name and target upload file inputs in search form. Columns in results table are displayed as expected (extra Upload table fields displayed for target upload file, not for a single target.)
