### PR TITLE
CADC-9369: reverse lower& upper bound for Plane.energy.bounds interval query

### DIFF
--- a/caom2-search-server/src/main/java/ca/nrc/cadc/caom2/ADQLGenerator.java
+++ b/caom2-search-server/src/main/java/ca/nrc/cadc/caom2/ADQLGenerator.java
@@ -203,8 +203,8 @@ public class ADQLGenerator extends AbstractPersistenceService {
             // upper & lower bound comparison rather than INTERSECTS, which is returning
             // invalid results
             // parameters below are IntervalSearch, upper bound, lower bound
-            sql = toIntervalSQL(s, getColumnName("Plane.energy.bounds.upper"),
-                getColumnName("Plane.energy.bounds.lower"));
+            sql = toIntervalSQL(s, getColumnName("Plane.energy.bounds.lower"),
+                getColumnName("Plane.energy.bounds.upper"));
             // TODO: reinstate this when CADC-9369 changes are reverted, after
             // CADC-9367 is completed
             //            sql = toIntersectSQL(s, getColumnName(CAOM2_ENERGY_UTYPE));

--- a/caom2-search-server/src/test/java/ca/nrc/cadc/caom2/ADQLGeneratorTest.java
+++ b/caom2-search-server/src/test/java/ca/nrc/cadc/caom2/ADQLGeneratorTest.java
@@ -152,10 +152,9 @@ public class ADQLGeneratorTest extends AbstractUnitTest<ADQLGenerator>
         //        assertEquals("SQL doesn't match.",
         //                     "INTERSECTS( INTERVAL( 0.0, 888.0 ), Plane.energy_bounds_samples ) = 1",
         //                     sql2);
-
-
+        
         assertEquals("SQL doesn't match.",
-            "Plane.energy_bounds_upper <= 888.0 AND 88.0 <= Plane.energy_bounds_lower",
+            "Plane.energy_bounds_lower <= 888.0 AND 88.0 <= Plane.energy_bounds_upper",
             sql);
 
         final IntervalSearch intervalSearch2 =
@@ -163,7 +162,7 @@ public class ADQLGeneratorTest extends AbstractUnitTest<ADQLGenerator>
         final String sql2 = getTestSubject().toSQL(intervalSearch2, null,
             false);
         assertEquals("SQL doesn't match.",
-            "Plane.energy_bounds_upper <= 888.0",
+            "Plane.energy_bounds_lower <= 888.0",
             sql2);
 
 


### PR DESCRIPTION
Were reversed in commit #196, so results of query were wrong.