### PR TITLE
CADC-9369: change to contains interval

### DIFF
--- a/caom2-search-server/build.gradle
+++ b/caom2-search-server/build.gradle
@@ -46,5 +46,5 @@ dependencies {
 
 sourceCompatibility = 1.8
 group = 'org.opencadc'
-version = '2.12.9'
+version = '2.12.10'
 

--- a/caom2-search-server/src/main/java/ca/nrc/cadc/caom2/ADQLGenerator.java
+++ b/caom2-search-server/src/main/java/ca/nrc/cadc/caom2/ADQLGenerator.java
@@ -211,6 +211,7 @@ public class ADQLGenerator extends AbstractPersistenceService {
         } else if (CAOM2_TIME_UTYPE.equals(s.getName())) {
             sql = toIntersectSQL(s, getColumnName(CAOM2_TIME_UTYPE));
         } else if (OBSCORE_ENERGY_UTYPE.equals(s.getName())) {
+            // When CADC-9367 is done, change this to match CAOM@_ENERGY_UTYPE search type
             sql = toIntervalSQL(s,
                                 getColumnName(OBSCORE_ENERGY_UTYPE + ".LoLimit"),
                                 getColumnName(OBSCORE_ENERGY_UTYPE + ".HiLimit"));

--- a/caom2-search-server/src/main/java/ca/nrc/cadc/caom2/ADQLGenerator.java
+++ b/caom2-search-server/src/main/java/ca/nrc/cadc/caom2/ADQLGenerator.java
@@ -150,29 +150,29 @@ public class ADQLGenerator extends AbstractPersistenceService {
      * @param col2 The upper bound column to search on.
      * @return String SQL fragment.
      */
-    private String toIntervalSQL(final IntervalSearch s, final String col1,
-                                 final String col2) {
+    private String toIntervalSQL(final IntervalSearch s, final String lowerBoundColName,
+                                 final String upperBoundColName) {
         final StringBuilder sb = new StringBuilder();
 
         if ((s.getLower() != null) && (s.getUpper() != null)) {
             // contains
-            sb.append(col1);
+            sb.append(lowerBoundColName);
             sb.append(" <= ");
-            sb.append(s.getUpper());
-            sb.append(" AND ");
             sb.append(s.getLower());
+            sb.append(" AND ");
+            sb.append(s.getUpper());
             sb.append(" <= ");
-            sb.append(col2);
+            sb.append(upperBoundColName);
         } else if (s.getUpper() != null) {
             // below
-            sb.append(col1);
+            sb.append(upperBoundColName);
             sb.append(" <= ");
             sb.append(s.getUpper());
         } else if (s.getLower() != null) {
             // above
+            sb.append(lowerBoundColName);
+            sb.append(" >= ");
             sb.append(s.getLower());
-            sb.append(" <= ");
-            sb.append(col2);
         }
 
         return sb.toString();
@@ -215,8 +215,8 @@ public class ADQLGenerator extends AbstractPersistenceService {
                                 getColumnName(OBSCORE_ENERGY_UTYPE + ".LoLimit"),
                                 getColumnName(OBSCORE_ENERGY_UTYPE + ".HiLimit"));
         } else if (OBSCORE_TIME_UTYPE.equals(s.getName())) {
-            sql = toIntervalSQL(s, getColumnName(OBSCORE_TIME_UTYPE + ".StopTime"),
-                                getColumnName(OBSCORE_TIME_UTYPE + ".StartTime"));
+            sql = toIntervalSQL(s, getColumnName(OBSCORE_TIME_UTYPE + ".StartTime"),
+                                getColumnName(OBSCORE_TIME_UTYPE + ".StopTime"));
         } else {
             throw new IllegalArgumentException("cannot use IntervalSearch with utype=" + s.getName());
         }

--- a/caom2-search-server/src/test/java/ca/nrc/cadc/caom2/ADQLGeneratorTest.java
+++ b/caom2-search-server/src/test/java/ca/nrc/cadc/caom2/ADQLGeneratorTest.java
@@ -152,19 +152,20 @@ public class ADQLGeneratorTest extends AbstractUnitTest<ADQLGenerator>
         //        assertEquals("SQL doesn't match.",
         //                     "INTERSECTS( INTERVAL( 0.0, 888.0 ), Plane.energy_bounds_samples ) = 1",
         //                     sql2);
-        
+
+        System.out.println(sql);
         assertEquals("SQL doesn't match.",
-            "Plane.energy_bounds_lower <= 888.0 AND 88.0 <= Plane.energy_bounds_upper",
+            "Plane.energy_bounds_lower <= 88.0 AND 888.0 <= Plane.energy_bounds_upper",
             sql);
 
         final IntervalSearch intervalSearch2 =
             new IntervalSearch("Plane.energy.bounds.samples", null, 888.0d, "m");
         final String sql2 = getTestSubject().toSQL(intervalSearch2, null,
             false);
+        System.out.println(sql2);
         assertEquals("SQL doesn't match.",
-            "Plane.energy_bounds_lower <= 888.0",
+            "Plane.energy_bounds_upper <= 888.0",
             sql2);
-
 
     }
 


### PR DESCRIPTION
as per Dbohlender request, :
David Bohlender  2 days ago
@pdowler the astros agree that energy queries should “contain” the wavelengths specified in the constraint.
Here’s an example where clause that should then return 10 DAO datasets when 4760..4960A is used for the “Spectral Coverage” constraint (i.e. the spectrum contains the hydrogen H-beta line at 4861A +/- about 100A on either side of it):

WHERE  ( lower(Observation.observationID) = 'dao_c122_2016_00686*' 
AND Plane.energy_bounds_lower <= 4.76E-7 
AND 4.96E-7 <= Plane.energy_bounds_upper 
AND  ( Plane.quality_flag IS NULL OR Plane.quality_flag != 'junk' ) )

The query should NOT return any datasets when the constraint is set to 4760..5300A or 4500..5000A (as examples). 

... tested with the above example.